### PR TITLE
don't parse arguments of attribute if there are whitespaces between name and lparen in custom attribute

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4055,6 +4055,15 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
 
 bool Parser::isCustomAttributeArgument() {
   BacktrackingScope backtrack(*this);
+  // if there is whitespace between attribute name and lparen, 
+  // don't treat it as arguments of the attribute.
+  // e.g.: closure { @MainActor (a, b) in ... }
+  if (Context.isSwiftVersionAtLeast(6) &&
+      Tok.isFollowingLParen() && 
+      getEndOfPreviousLoc() != Tok.getLoc()) {
+    return false;
+  }
+  
   if (skipSingle().hasCodeCompletion())
     return true;
 

--- a/test/Parse/attribute_spacing.swift
+++ b/test/Parse/attribute_spacing.swift
@@ -1,11 +1,18 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5 -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
 
-@ MainActor  // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+// expected-swift5-warning@+2 {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+// expected-swift6-error@+1 {{extraneous whitespace between '@' and attribute name}}
+@ MainActor  
 class Foo {
-  func funcWithEscapingClosure(_ x: @ escaping () -> Int) {} // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+  // expected-swift5-warning@+2 {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+  // expected-swift6-error@+1 {{extraneous whitespace between '@' and attribute name}}
+  func funcWithEscapingClosure(_ x: @ escaping () -> Int) {}
 }
 
-@available (*, deprecated) // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+// expected-swift5-warning@+2 {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+// expected-swift6-error@+1 {{extraneous whitespace between attribute name and '('}}
+@available (*, deprecated)
 func deprecated() {}
 
 @propertyWrapper
@@ -16,18 +23,24 @@ struct MyPropertyWrapper {
 }
 
 struct PropertyWrapperTest {
-  @MyPropertyWrapper (param: 2)  // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+  // expected-swift5-warning@+4 {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+  // expected-swift6-error@+3 {{expected 'var' keyword in property declaration}}
+  // expected-swift6-error@+2 {{property declaration does not bind any variables}}
+  // expected-swift6-error@+1 {{expected pattern}}
+  @MyPropertyWrapper (param: 2)
   var x: Int
 }
 
-let closure1 = { @MainActor (a, b) in // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+// expected-swift5-warning@+1 {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
+let closure1 = { @MainActor (a: Int, b: Int) in
 }
 
 let closure2 = { @MainActor
   (a: Int, b: Int) in
 }
 
-// expected-warning@+1{{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+// expected-swift5-warning@+2{{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
+// expected-swift6-error@+1{{extraneous whitespace between '@' and attribute name}}
 @ 
 MainActor
 func mainActorFunc() {}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
